### PR TITLE
adding details in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 A collection of Jupyter notebook that can be used to associate Rubin Science Platform data to a Zooniverse citizen science project.
 
 These notebooks are intended to be used within the Rubin Science Platform Notebook Aspect for associating Rubin data with a Zooniverse citizen science project.
+
+The Citizen_Science_Testing.ipynb is most relevant; it guides a PI through the process of sending data from the Rubin Science Platform (RSP) to the Zooniverse and retrieving classifications from Zooniverse.
+
+The utils.py script contains general plotting, butler, and manifest utilities. If necessary, it can be modified carefully.
+
+The rubin_citsci_core_pipeline.py script contains utilities related to the citizen science pipeline. Do not modify.
+
+Additional notebooks are deprecated.


### PR DESCRIPTION
Hi @ericdrosas87 I'm updating our readme to have more details about the target notebooks. Feel free to add suggestions in this thread. Right now I've added the following text:

> The Citizen_Science_Testing.ipynb is most relevant; it guides a PI through the process of sending data from the Rubin Science Platform (RSP) to the Zooniverse and retrieving classifications from Zooniverse.
> 
> The utils.py script contains general plotting, butler, and manifest utilities. If necessary, it can be modified carefully.
> 
> The rubin_citsci_core_pipeline.py script contains utilities related to the citizen science pipeline. Do not modify.
> 
> Additional notebooks are deprecated.

Is there a better way to suggest that people not look at the other notebooks?